### PR TITLE
DockerImage 8 updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM golang:alpine3.17
-WORKDIR /k8s-api
+# Build
+FROM golang:alpine AS build
+
+WORKDIR /k8-api
 COPY . .
-RUN apk update && \
-    apk upgrade && \
-    apk --update add \
-        gcc \
-        g++ \
-        build-base && \
-    go mod tidy
-CMD ["go","run","server.go"]
+RUN go mod download && \
+    GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-s -w"
+
+# Deploy
+FROM alpine
+COPY --from=build /k8-api/k8-api .
+
+ENTRYPOINT ["./k8-api"]
+# CMD WALA PART?
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The project can be run *inside* the cluster and from *outside* the cluster. We w
     serviceAccount: <Name-of-your-serviceaccount> 
     containers:
     - name: <your-custom-name>
-      image: kitarp29/k8s-api:6.0
+      image: kitarp29/k8s-api:8.0
       ports:
       - containerPort: 8000
   EOF

--- a/yamls/pod.yaml
+++ b/yamls/pod.yaml
@@ -6,6 +6,6 @@ spec:
   serviceAccount: kube-ez
   containers:
   - name: kube-ez
-    image: kitarp29/k8s-api:6.0
+    image: kitarp29/k8s-api:8.0
     ports:
     - containerPort: 8000


### PR DESCRIPTION
Reduced the image size to 16 MB
Reduced the image size to around **97%**. Earlier Images were of ~500 MB!
New Docker Image: [Here](https://hub.docker.com/layers/kitarp29/k8s-api/8.0/images/sha256-ee822e40e78b2fa6146f36f1cd6694c723b1a4e6ca84e4f908944167eefed8a0?context=repo) 
This is so AWESOME!
Time to close: 
- #27
Signed-off-by: kitarp29 <kitarpsinghrajpoot@gmail.com>